### PR TITLE
Add support for the &apos; entity

### DIFF
--- a/src/libwrapper.cpp
+++ b/src/libwrapper.cpp
@@ -49,6 +49,9 @@ static std::string xdxf2text(const char *p)
 			} else if (g_str_has_prefix(p, "&quot;")) {
 				res+="\"";
 				p+=5;
+			} else if (g_str_has_prefix(p, "&apos;")) {
+				res+="'";
+				p+=5;
 			} else
 				res+=*p;
 			continue;


### PR DESCRIPTION
Found that "The Collaborative International Dictionary of English v.0.44" has lots of those `&apos;` entities.
